### PR TITLE
Add graveyard functionality to Population

### DIFF
--- a/examples/basic/convex.py
+++ b/examples/basic/convex.py
@@ -50,7 +50,7 @@ optimiser.set_seed(x_seed, y_seed)
 # run to 100, but it is illustrative to change this number and see how the
 # results of this code (see below) change!
 n_iterations = 100
-optimiser.initialise_run()
+optimiser.initialise_run(graveyard_path="./graveyard.csv")
 for iteration in range(n_iterations):
     optimiser.run_iteration()
 

--- a/examples/basic/convex.py
+++ b/examples/basic/convex.py
@@ -53,6 +53,7 @@ n_iterations = 100
 optimiser.initialise_run(graveyard_path="./graveyard.csv")
 for iteration in range(n_iterations):
     optimiser.run_iteration()
+optimiser.end_run()
 
 # To visually *see* how the optimisation algorithm did, we plot the data from
 # the latest iteration in a scatter plot (with function values indicated by

--- a/examples/basic/multiple_global_minima.py
+++ b/examples/basic/multiple_global_minima.py
@@ -52,6 +52,7 @@ n_iterations = 100
 optimiser.initialise_run(graveyard_path="./graveyard.csv")
 for iteration in range(n_iterations):
     optimiser.run_iteration()
+optimiser.end_run()
 
 # To visually *see* how the optimisation algorithm did, we plot the data from
 # the latest iteration in a scatter plot (with function values indicated by

--- a/examples/basic/multiple_global_minima.py
+++ b/examples/basic/multiple_global_minima.py
@@ -49,7 +49,7 @@ optimiser.set_seed(x_seed, y_seed)
 # run to 100, but it is illustrative to change this number and see how the
 # results of this code (see below) change!
 n_iterations = 100
-optimiser.initialise_run()
+optimiser.initialise_run(graveyard_path="./graveyard.csv")
 for iteration in range(n_iterations):
     optimiser.run_iteration()
 

--- a/examples/basic/multiple_local_minima.py
+++ b/examples/basic/multiple_local_minima.py
@@ -58,6 +58,7 @@ n_iterations = 100
 optimiser.initialise_run(graveyard_path="./graveyard.csv")
 for iteration in range(n_iterations):
     optimiser.run_iteration()
+optimiser.end_run()
 
 # To visually *see* how the optimisation algorithm did, we plot the data from
 # the latest iteration in a scatter plot (with function values indicated by

--- a/examples/basic/multiple_local_minima.py
+++ b/examples/basic/multiple_local_minima.py
@@ -55,7 +55,7 @@ optimiser.set_seed(x_seed, y_seed)
 # run to 100, but it is illustrative to change this number and see how the
 # results of this code (see below) change!
 n_iterations = 100
-optimiser.initialise_run()
+optimiser.initialise_run(graveyard_path="./graveyard.csv")
 for iteration in range(n_iterations):
     optimiser.run_iteration()
 

--- a/examples/callbacks/README.md
+++ b/examples/callbacks/README.md
@@ -40,3 +40,4 @@ Below you can find a list of locations to which you can assign callback function
 - **`after_kill_controller_call`**: called right after the kill controller, that determines which points are removed at the end of the iteration, is called. It is essentially the same as `before_kill_data`.
 - **`before_kill_data`**: called before the data marked for removal is removed from the population. It is essentially the same as `after_kill_controller_call`.
 - **`at_end_of_iteration`**: called at the end of each iteration, i.e. after the data marked for removal is removed.
+- **`at_end_of_run`**: called at the end of a run, i.e. the final step of the `ParticleFilter.end_run` method.

--- a/examples/callbacks/running_with_callbacks.py
+++ b/examples/callbacks/running_with_callbacks.py
@@ -57,9 +57,9 @@ def store_population(iteration, width, function, population):
 # Add these callbacks to the particle filter. The README in the callback
 # examples folder lists which handles you can define.
 optimiser.add_callback("at_start_of_iteration", print_iteration_number)
-optimiser.add_callback("after_kill_data", store_population)
+#optimiser.add_callback("after_kill_data", store_population)
 optimiser.add_callback("at_end_of_iteration", print_population_size)
-optimiser.add_callback("at_end_of_iteration", store_population)
+optimiser.add_callback("before_kill_controller_call", store_population)
 
 # That's all! We can now run the iterations of the particle filter, after
 # initialising the run, with a simple for-loop and the `run_iteration` method

--- a/examples/high_dimensionality/convex.py
+++ b/examples/high_dimensionality/convex.py
@@ -59,6 +59,7 @@ optimiser.initialise_run(graveyard_path="./graveyard.csv")
 for iteration in range(n_iterations):
     print("Iteration {}".format(iteration))
     optimiser.run_iteration()
+optimiser.end_run()
 
 # As we are however interested in the minimum, so let's print the point (and
 # the function value) for the smallest point found.

--- a/examples/high_dimensionality/convex.py
+++ b/examples/high_dimensionality/convex.py
@@ -55,7 +55,7 @@ optimiser.set_seed(x_seed, y_seed)
 
 # Let's run the optimisation.
 n_iterations = 100
-optimiser.initialise_run()
+optimiser.initialise_run(graveyard_path="./graveyard.csv")
 for iteration in range(n_iterations):
     print("Iteration {}".format(iteration))
     optimiser.run_iteration()

--- a/examples/high_dimensionality/convex_animation.py
+++ b/examples/high_dimensionality/convex_animation.py
@@ -77,7 +77,8 @@ for iteration in range(n_iterations):
     plt.hist(y, 20)
     plt.xscale('log')
     camera.snap()
-    
+optimiser.end_run()
+
 # Store the animation as convex.mp4 in the current folder.
 animation = camera.animate()
 animation.save('convex.mp4')

--- a/examples/high_dimensionality/convex_animation.py
+++ b/examples/high_dimensionality/convex_animation.py
@@ -68,7 +68,7 @@ hist_max = np.sqrt(15*15*n_dimensions)+1
 
 # Let's run the iterations and create the histogram we need in each of them.
 n_iterations = 100
-optimiser.initialise_run()
+optimiser.initialise_run(graveyard_path="./graveyard.csv")
 for iteration in range(n_iterations):
     print("Iteration {}".format(iteration))
     optimiser.run_iteration()

--- a/examples/high_dimensionality/multiple_local_minima.py
+++ b/examples/high_dimensionality/multiple_local_minima.py
@@ -81,6 +81,7 @@ for iteration in range(1, n_iterations+1):
     if iteration % 10 == 0:
         print("Iteration {}".format(iteration))
     optimiser.run_iteration()
+optimiser.end_run()
 
 # As we are however interested in the minimum, so let's print the point (and
 # the function value) for the smallest point found.

--- a/examples/high_dimensionality/multiple_local_minima.py
+++ b/examples/high_dimensionality/multiple_local_minima.py
@@ -75,7 +75,7 @@ optimiser.set_seed(x_seed, y_seed)
 
 # Let's run the optimisation.
 n_iterations = 250
-optimiser.initialise_run()
+optimiser.initialise_run(graveyard_path="./graveyard.csv")
 
 for iteration in range(1, n_iterations+1):
     if iteration % 10 == 0:

--- a/examples/high_dimensionality/multiple_local_minima_animation.py
+++ b/examples/high_dimensionality/multiple_local_minima_animation.py
@@ -88,8 +88,8 @@ hist_max = np.sqrt(15*15*n_dimensions)+1
 
 # Let's run the optimisation.
 n_iterations = 250
-optimiser.initialise_run(graveyard_path="./graveyard.csv")
 
+optimiser.initialise_run(graveyard_path="./graveyard.csv")
 for iteration in range(1, n_iterations+1):
     if iteration % 10 == 0:
         print("Iteration {}".format(iteration))
@@ -101,6 +101,7 @@ for iteration in range(1, n_iterations+1):
     plt.xscale('log')
     plt.yscale('log')
     camera.snap()
+optimiser.end_run()
 
 optimiser.population.save("population.csv")
 

--- a/examples/high_dimensionality/multiple_local_minima_animation.py
+++ b/examples/high_dimensionality/multiple_local_minima_animation.py
@@ -88,7 +88,7 @@ hist_max = np.sqrt(15*15*n_dimensions)+1
 
 # Let's run the optimisation.
 n_iterations = 250
-optimiser.initialise_run()
+optimiser.initialise_run(graveyard_path="./graveyard.csv")
 
 for iteration in range(1, n_iterations+1):
     if iteration % 10 == 0:

--- a/examples/population/extract_data.py
+++ b/examples/population/extract_data.py
@@ -77,3 +77,7 @@ x, y = population.get_procreating_data()  # Will return approx. 75 points
 # To get all data points that have been slated for deletion at the end of the
 # current iteration, we request all data points on the 'kill list'.
 x, y = population.get_data_on_kill_list()
+
+# If you also want to get the iteration of origin for the to-be-deleted points
+# this method is the one you are looking for
+x, y, origin = population.get_data_on_kill_list_with_origin()

--- a/examples/width/missampled_seed.py
+++ b/examples/width/missampled_seed.py
@@ -67,7 +67,7 @@ optimiser.set_seed(x_seed, y_seed)
 n_iterations = 100
 widths = [None] * n_iterations
 
-optimiser.initialise_run()
+optimiser.initialise_run(graveyard_path="./graveyard.csv")
 for iteration in range(n_iterations):
     optimiser.run_iteration()
     widths[iteration] = optimiser.width

--- a/examples/width/missampled_seed.py
+++ b/examples/width/missampled_seed.py
@@ -72,6 +72,7 @@ for iteration in range(n_iterations):
     optimiser.run_iteration()
     widths[iteration] = optimiser.width
     print(optimiser.width)
+optimiser.end_run()
 
 # Let's create a plot of the widths used for each of the epochs, to validate
 # that it indeed decreased the width at the requested rate.

--- a/examples/width/width_decay.py
+++ b/examples/width/width_decay.py
@@ -75,7 +75,7 @@ optimiser.set_seed(x_seed, y_seed)
 n_iterations = 100
 widths = [None] * n_iterations
 
-optimiser.initialise_run()
+optimiser.initialise_run(graveyard_path="./graveyard.csv")
 for iteration in range(n_iterations):
     optimiser.run_iteration()
     widths[iteration] = optimiser.width

--- a/examples/width/width_decay.py
+++ b/examples/width/width_decay.py
@@ -79,6 +79,7 @@ optimiser.initialise_run(graveyard_path="./graveyard.csv")
 for iteration in range(n_iterations):
     optimiser.run_iteration()
     widths[iteration] = optimiser.width
+optimiser.end_run()
 
 # Let's create a plot of the widths used for each of the epochs, to validate
 # that it indeed decreased the width at the requested rate.

--- a/particlefilter/particlefilter.py
+++ b/particlefilter/particlefilter.py
@@ -175,6 +175,7 @@ class ParticleFilter:
         - after_kill_controller_call
         - before_kill_data
         - at_end_of_iteration
+        - at_end_of_run
 
         Args:
             name: Name of the callback which has to be checked for existence.
@@ -333,6 +334,7 @@ class ParticleFilter:
             'after_kill_controller_call': [],
             'before_kill_data': [],
             'at_end_of_iteration': [],
+            'at_end_of_run': []
         }
 
     def add_callback(self, name, function=None):
@@ -585,3 +587,12 @@ class ParticleFilter:
         self.callback('before_kill_data')
         self.population.end_iteration()
         self.callback('at_end_of_iteration')
+
+    def end_run(self):
+        """ Ends the run by sending all remaining data to the graveyard and 
+        resetting the ParticleFilter object through the `reset` method.
+        """
+        self.population.send_to_graveyard(
+            *self.population.get_data_with_origin_information())
+        self.reset()
+        self.callback("at_end_of_run")

--- a/particlefilter/particlefilter.py
+++ b/particlefilter/particlefilter.py
@@ -589,7 +589,7 @@ class ParticleFilter:
         self.callback('at_end_of_iteration')
 
     def end_run(self):
-        """ Ends the run by sending all remaining data to the graveyard and 
+        """ Ends the run by sending all remaining data to the graveyard and
         resetting the ParticleFilter object through the `reset` method.
         """
         self.population.send_to_graveyard(

--- a/particlefilter/particlefilter.py
+++ b/particlefilter/particlefilter.py
@@ -501,10 +501,32 @@ class ParticleFilter:
         # Return procreation rate
         return procreation_rates.astype(np.int32)
 
-    def initialise_run(self):
-        """ Start the run by initialising the iteration counter. """
+    def initialise_run(self, graveyard_path=None):
+        """ Start the run by initialising the iteration counter.
+        
+        By setting `graveyard_path` to anything than its default `None` value,
+        the `Population` object will store all killed data points in the
+        provided path, in .csv format. The file will contain the coordinates
+        `x`, the function values `y` and the iteration of origin. Use the
+        `change_graveyard` method to change the target file (which you can
+        do mid-run).
+        
+        Args:
+            graveyard_path: Path to which killed data points should be stored.
+        """
         self.iteration = 0
         self.callback("at_start_of_run")
+        self.population.make_graveyard(graveyard_path)
+    
+    def change_graveyard(self, graveyard_path=None):
+        """ Change the location to which killed datapoints should be written.
+        
+        Args:
+            graveyard_path: Path to which killed data points should be stored.
+                Data is stored in .csv format and contains the coordinates `x`,
+                the function values `y` and the iteration of origin.
+        """
+        self.population.make_graveyard(graveyard_path)
 
     def run_iteration(self):
         """ This method runs an interation of the particle filter algorithm.
@@ -559,7 +581,7 @@ class ParticleFilter:
         kill_list = self.kill_controller(y, is_new, self.iteration_size)
         self.population.set_kill_list(kill_list)
         self.callback('after_kill_controller_call')
-        # Kill data and end the iteration
+        # Kill data, store to graveyard and end the iteration
         self.callback('before_kill_data')
         self.population.end_iteration()
         self.callback('at_end_of_iteration')

--- a/particlefilter/particlefilter.py
+++ b/particlefilter/particlefilter.py
@@ -503,24 +503,24 @@ class ParticleFilter:
 
     def initialise_run(self, graveyard_path=None):
         """ Start the run by initialising the iteration counter.
-        
+
         By setting `graveyard_path` to anything than its default `None` value,
         the `Population` object will store all killed data points in the
         provided path, in .csv format. The file will contain the coordinates
         `x`, the function values `y` and the iteration of origin. Use the
         `change_graveyard` method to change the target file (which you can
         do mid-run).
-        
+
         Args:
             graveyard_path: Path to which killed data points should be stored.
         """
         self.iteration = 0
         self.callback("at_start_of_run")
         self.population.make_graveyard(graveyard_path)
-    
+
     def change_graveyard(self, graveyard_path=None):
         """ Change the location to which killed datapoints should be written.
-        
+
         Args:
             graveyard_path: Path to which killed data points should be stored.
                 Data is stored in .csv format and contains the coordinates `x`,

--- a/particlefilter/population.py
+++ b/particlefilter/population.py
@@ -130,6 +130,7 @@ class Population:
         self.kill_list[:len(kill_list)] = kill_list
 
     """ Smart selection getters """
+
     # Methods in this section allow the user to quickly get subsets of or
     # metrics about the data stored in this `Population` object.
 
@@ -185,7 +186,7 @@ class Population:
             y: numpy.ndarray containing the function values for the returned
                 `x`. """
         return (self.x[self.kill_list], self.y[self.kill_list])
-    
+
     def get_data_on_kill_list_with_origin(self):
         """ Returns the coordinates, function values and origin iteration for
         which the removal flag in the `kill_list` property is `True`.
@@ -198,8 +199,7 @@ class Population:
                 `x`.
             origin: `numpy.ndarray` containing the iteration ID in which each
                 of the data points in `x`. """
-        return (self.x[self.kill_list],
-                self.y[self.kill_list],
+        return (self.x[self.kill_list], self.y[self.kill_list],
                 self.origin_iteration[self.kill_list])
 
     def get_latest_data(self):
@@ -281,6 +281,7 @@ class Population:
         return means, stdevs
 
     """ Methods for validation and reshaping of input """
+
     # The `Population` class expects input given by the user to be of a
     # certain type and shape. The methods defined in this section apply checks
     # to a wide range of input given by the user and return nicely formatted
@@ -531,6 +532,7 @@ class Population:
         return kill_list
 
     """ Data methods """
+
     # Data methods allow the addition of new data to the Population object
     # and the configuration of meta arrays, like `procreation_rates` and
     # `kill_list`. Although all these values are stored in properties of the
@@ -678,6 +680,7 @@ class Population:
         self.kill_list = kill_list
 
     """ Iteration methods """
+
     # Iteration methods are used to control the iteration. Examples of
     # iteration methods are the `procreate` method, used to sample new data
     # points from provided gaussian stdevs and procreation rates, and the
@@ -880,6 +883,7 @@ class Population:
         self._now += 1
 
     """ Storage and abstraction methods """
+
     # These storage and abstraction methods allow the user to store the current
     # state of the Population object and to get general information about
     # it.
@@ -902,7 +906,7 @@ class Population:
 
         Args:
             filename: Path to which the data should be written. If set to
-                `None`, the graveyard will be considered 'not set' and no 
+                `None`, the graveyard will be considered 'not set' and no
                 killed data will be stored. """
         # Close previous graveyard (if exists)
         if self.has_graveyard():
@@ -912,7 +916,7 @@ class Population:
         if filename is not None:
             self._graveyard_handle = open(os.path.abspath(filename), 'w')
             self._graveyard_has_header = False
-    
+
     def send_to_graveyard(self, x, y, origin):
         """ Store provided data in the graveyard file, defined with the
         `make_graveyard` method.
@@ -928,15 +932,16 @@ class Population:
         if self.has_graveyard():
             # Write header if not already done
             if not self._graveyard_has_header:
-                header = ['current_iteration', 'origin_iteration'] + ['x'+str(i) for i in range(len(x[0]))] + ['y']
+                header = ['current_iteration', 'origin_iteration'
+                          ] + ['x' + str(i) for i in range(len(x[0]))] + ['y']
                 self._graveyard_handle.write(','.join(header) + "\n")
                 self._graveyard_has_header = True
             # Populate with data
-            data = np.hstack((np.ones((len(x), 1))*self._now,
-                              x, y.reshape(-1, 1),
+            data = np.hstack((np.ones(
+                (len(x), 1)) * self._now, x, y.reshape(-1, 1),
                               origin.reshape(-1, 1))).astype(np.str).tolist()
             addition = "\n".join([','.join(data[i]) for i in range(len(data))])
-            self._graveyard_handle.write(addition+"\n")
+            self._graveyard_handle.write(addition + "\n")
             self._graveyard_handle.flush()
 
     def save(self, filepath):

--- a/particlefilter/population.py
+++ b/particlefilter/population.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import os
 import logging
 import numpy as np
 
@@ -907,7 +908,7 @@ class Population:
             self._graveyard_handle.close()
         self._graveyard_handle = None
         if filename is not None:
-            self._graveyard_handle = open(filename)
+            self._graveyard_handle = open(os.path.abspath(filename), 'w')
     
     def send_to_graveyard(self, x, y, origin):
         """ Store provided data in the graveyard file, defined with the

--- a/particlefilter/population.py
+++ b/particlefilter/population.py
@@ -894,9 +894,7 @@ class Population:
         Returns:
             Boolean indicating if the graveyard has been defined (`True`) or
             not (`False`). """
-        if hasattr(self, '_graveyard_handle'):
-            return self._graveyard_handle is not None
-        return False
+        return self._graveyard_handle is not None
 
     def make_graveyard(self, filename=None):
         """ Creates a graveyard file to which, before the end of each

--- a/tests/test_particlefilter.py
+++ b/tests/test_particlefilter.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 """ Tests for the ParticleFilter class in the particlefilter package. """
+import os
 import pytest
 import numpy as np
 
@@ -145,3 +146,29 @@ def test_run_iteration():
 
     pf.initialise_run()
     pf.run_iteration()
+
+
+def test_run_iteration_with_graveyard(tmp_path):
+    pf = ParticleFilter(func, 10,
+                        initial_width=0.00001,
+                        boundaries=np.array([[0, 1], [0, 1]]),
+                        kill_controller=get_kill_controller(0.2, False))
+    graveyard = str(tmp_path)+"/graveyard.csv"
+
+    x = np.random.rand(100, 2)
+    y = np.arange(100)
+    pf.set_seed(x, y)
+
+    pf.initialise_run(graveyard)
+    pf.run_iteration()
+    assert os.path.exists(graveyard)
+    os.remove(graveyard)
+    assert not os.path.exists(graveyard)
+
+    pf.change_graveyard(None)
+    pf.run_iteration()
+    assert not os.path.exists(graveyard)
+
+    pf.change_graveyard(graveyard)
+    pf.run_iteration()
+    assert os.path.exists(graveyard)

--- a/tests/test_particlefilter.py
+++ b/tests/test_particlefilter.py
@@ -146,6 +146,7 @@ def test_run_iteration():
 
     pf.initialise_run()
     pf.run_iteration()
+    pf.end_run()
 
 
 def test_run_iteration_with_graveyard(tmp_path):
@@ -172,3 +173,22 @@ def test_run_iteration_with_graveyard(tmp_path):
     pf.change_graveyard(graveyard)
     pf.run_iteration()
     assert os.path.exists(graveyard)
+    pf.end_run()
+
+
+def test_end_iteration_with_graveyard(tmp_path):
+    pf = ParticleFilter(func, 100,
+                        initial_width=0.00001,
+                        boundaries=np.array([[0, 1], [0, 1]]),
+                        kill_controller=get_kill_controller(0.2, False))
+    graveyard = str(tmp_path)+"/graveyard.csv"
+
+    x = np.random.rand(100, 2)
+    y = np.arange(100)
+    pf.set_seed(x, y)
+    pf.initialise_run(graveyard)
+    pf.run_iteration()
+    pf.end_run()
+
+    graveyard = np.genfromtxt(graveyard, delimiter=',', skip_header=1)
+    assert graveyard.shape == (200, 5)

--- a/tests/test_population.py
+++ b/tests/test_population.py
@@ -352,3 +352,19 @@ def test_graveyard(tmp_path):
     assert pop._graveyard_handle is not None
     pop.make_graveyard()
     assert pop._graveyard_handle is None
+
+
+def test_empty_graveyard(tmp_path):
+    x, y, pop = get_population_and_data(10)
+    path = str(tmp_path)+"/graveyard.csv"
+    pop.make_graveyard(path)
+
+    origin = np.zeros(10).reshape(10, 1)
+    pop.send_to_graveyard(x, y, origin)
+    graveyard = np.genfromtxt(path, skip_header=1, delimiter=',')
+    assert graveyard.shape == (10, 5)
+
+    pop.make_graveyard()
+    pop.send_to_graveyard(x, y, origin)
+    graveyard = np.genfromtxt(path, skip_header=1, delimiter=',')
+    assert graveyard.shape == (10, 5)

--- a/tests/test_population.py
+++ b/tests/test_population.py
@@ -324,3 +324,31 @@ def test_save_2(tmp_path):
     filepath = '{}/csv_file.csv'.format(tmp_path)
     pop.save(filepath)
     assert os.path.exists(filepath)
+
+
+def test_graveyard(tmp_path):
+    x, y, pop = get_population_and_data(10)
+
+    assert not pop.has_graveyard()
+    path = str(tmp_path)+"/graveyard.csv"
+    # Make sure file is made by make_graveyard
+    assert not os.path.exists(path)
+    pop.make_graveyard(path)
+    assert os.path.exists(path)
+    assert pop.has_graveyard()
+
+    # Populate graveyard
+    pop.append(x+1, y+1)
+    pop._now += 1
+    pop.append(x+2, y+2)
+    pop.set_kill_list(pop.origin_iteration == 0.0)
+    pop.send_to_graveyard(*pop.get_data_on_kill_list_with_origin())
+
+    # Assert that there are 10 datapoints on graveyard
+    graveyard = np.genfromtxt(path, skip_header=1, delimiter=',')
+    assert graveyard.shape == (10, 5)
+
+    # Set new graveyard
+    assert pop._graveyard_handle is not None
+    pop.make_graveyard()
+    assert pop._graveyard_handle is None


### PR DESCRIPTION
The graveyard functionality, accessible throught he initialise_run method of the ParticleFilter and the make_graveyard method of the Population, allows the user to define a location to which data points, their function values and their origin iterations are stored when they are killed (or when the thing run ends).